### PR TITLE
CI: fix rust-toolchain.toml and doctests

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "stable"
 targets = ["wasm32-wasip2"]

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -5,6 +5,7 @@
 //! using the [`http_server`] macro:
 //!
 //! ```no_run
+//! # use wstd::http::{Request, Response, IntoBody, server::{Finished, Responder}, body::IncomingBody};
 //! #[wstd::http_server]
 //! async fn main(request: Request<IncomingBody>, responder: Responder) -> Finished {
 //!     responder
@@ -49,7 +50,7 @@ impl Responder {
     /// # Example
     ///
     /// ```
-    /// # use wstd::http::{body::IncomingBody, BodyForthcoming, Response, Request};
+    /// # use wstd::http::{body::{IncomingBody, BodyForthcoming}, Response, Request};
     /// # use wstd::http::server::{Finished, Responder};
     /// # use crate::wstd::io::AsyncWrite;
     /// # async fn example(responder: Responder) -> Finished {
@@ -59,6 +60,7 @@ impl Responder {
     ///         .await;
     ///     Finished::finish(body, result, None)
     /// # }
+    /// # fn main() {}
     /// ```
     pub fn start_response(self, response: Response<BodyForthcoming>) -> OutgoingBody {
         let wasi_headers = header_map_to_wasi(response.headers()).expect("header error");
@@ -87,7 +89,7 @@ impl Responder {
     /// # Example
     ///
     /// ```
-    /// # use wstd::http::{body::IncomingBody, BodyForthcoming, IntoBody, Response, Request};
+    /// # use wstd::http::{body::{IncomingBody, BodyForthcoming}, IntoBody, Response, Request};
     /// # use wstd::http::server::{Finished, Responder};
     /// #
     /// # async fn example(responder: Responder) -> Finished {
@@ -95,6 +97,7 @@ impl Responder {
     ///         .respond(Response::new("Hello!\n".into_body()))
     ///         .await
     /// # }
+    /// # fn main() {}
     /// ```
     pub async fn respond<B: Body>(self, response: Response<B>) -> Finished {
         let headers = response.headers();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! **HTTP Client**
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 #![doc = include_str!("../tests/http_get.rs")]
 //! ```
 //!


### PR DESCRIPTION
CI is broken:
* `rust-toolchain.toml` was overriding the toolchain to 1.82 locally, but not on CI. The latest rust 1.89, running on CI, would fail due to doctests picking up more than before with --target wasm32-wasip2.
* the failing doctests are now fixed