### PR TITLE
move wasip2 re-export under `pub mod __internal`

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -126,10 +126,10 @@ pub fn attr_macro_http_server(_attr: TokenStream, item: TokenStream) -> TokenStr
     quote! {
         struct TheServer;
 
-        impl ::wstd::wasip2::exports::http::incoming_handler::Guest for TheServer {
+        impl ::wstd::__internal::wasip2::exports::http::incoming_handler::Guest for TheServer {
             fn handle(
-                request: ::wstd::wasip2::http::types::IncomingRequest,
-                response_out: ::wstd::wasip2::http::types::ResponseOutparam
+                request: ::wstd::__internal::wasip2::http::types::IncomingRequest,
+                response_out: ::wstd::__internal::wasip2::http::types::ResponseOutparam
             ) {
                 #(#attrs)*
                 #vis async fn __run(#inputs) #output {
@@ -146,7 +146,7 @@ pub fn attr_macro_http_server(_attr: TokenStream, item: TokenStream) -> TokenStr
             }
         }
 
-        ::wstd::wasip2::http::proxy::export!(TheServer with_types_in ::wstd::wasip2);
+        ::wstd::__internal::wasip2::http::proxy::export!(TheServer with_types_in ::wstd::__internal::wasip2);
 
         // Provide an actual function named `main`.
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,14 @@ pub use wstd_macro::attr_macro_http_server as http_server;
 pub use wstd_macro::attr_macro_main as main;
 pub use wstd_macro::attr_macro_test as test;
 
-// Re-export the wasi crate for use by the `http_server` macro.
+// Re-export the wasip2 crate for use only by `wstd-macro` macros. The proc
+// macros need to generate code that uses these definitions, but we don't want
+// to treat it as part of our public API with regards to semver, so we keep it
+// under `__internal` as well as doc(hidden) to indicate it is private.
 #[doc(hidden)]
-pub use wasip2;
+pub mod __internal {
+    pub use wasip2;
+}
 
 pub mod prelude {
     pub use crate::future::FutureExt as _;


### PR DESCRIPTION
Re-export the wasip2 crate for use only by `wstd-macro` macros. The proc
macros need to generate code that uses these definitions, but we don't want
to treat it as part of our public API with regards to semver, so we keep it
under `__internal` as well as doc(hidden) to indicate it is private.
