### PR TITLE
update futures-lite to 2.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ bytes = "1.10.1"
 cargo_metadata = "0.22"
 clap = { version = "4.5.26", features = ["derive"] }
 futures-core = "0.3.19"
-futures-lite = "1.12.0"
+futures-lite = "2.6.1"
 futures-concurrency = "7.6"
 humantime = "2.1.0"
 heck = "0.5"

--- a/test-programs/tests/http_server.rs
+++ b/test-programs/tests/http_server.rs
@@ -151,9 +151,11 @@ fn http_server() -> Result<()> {
     // connection
     match ureq::get("http://127.0.0.1:8081/response-body-fail").call() {
         Err(ureq::Error::Io(_transport)) => {}
-        result => {
-            panic!("/response-body-fail expected io error, got: {result:?}")
-        }
+        Ok(mut resp) => match resp.body_mut().read_to_vec() {
+            Err(ureq::Error::Io(_transport)) => {}
+            result => panic!("/response-body-fail expected io error, got: {result:?}"),
+        },
+        result => panic!("/response-body-fail expected io error, got: {result:?}"),
     }
 
     Ok(())


### PR DESCRIPTION
Closes #139 

Loosened up what behavior is accepted in tests as part of this upgrade. I'm not clear on why the dependency change also changed test behavior, or if its something that the latest wasmtime cli release introduced, or what, but the way I loosened the test makes sense for the particular behavior being tested.