### PR TITLE
Fix flaky `response-body-fail` test

### DIFF
--- a/test-programs/tests/http_server.rs
+++ b/test-programs/tests/http_server.rs
@@ -151,6 +151,14 @@ fn http_server() -> Result<()> {
     // connection
     match ureq::get("http://127.0.0.1:8081/response-body-fail").call() {
         Err(ureq::Error::Io(_transport)) => {}
+        Ok(mut response) => match response.body_mut().read_to_vec() {
+            Err(ureq::Error::Io(_transport)) => {}
+            body => {
+                panic!(
+                    "/response-body-fail expected io error, got: {response:?} with body {body:?}",
+                );
+            }
+        },
         result => {
             panic!("/response-body-fail expected io error, got: {result:?}")
         }


### PR DESCRIPTION
The `http_server` would fail ~1/10 times when running locally for me and failed once on CI [here](https://github.com/bytecodealliance/wstd/actions/runs/33630700944/job/100249118155?pr=142). This would be for testing the case where the server hits an error while streaming the body. The issue seems to be that occasionally the `ureq` call will come back `Ok` and the error is only exposed while reading the body.

I'm not sure why `ureq` is non-deterministic in where it reports the error, but it seems entirely reasonable to only report it when streaming the body given that the server only errors when writing the body. So this just modifies the test to pass in that case as well.